### PR TITLE
fixes bootnode option use as it changed in the docker image

### DIFF
--- a/pantheon/bootnode_start.sh
+++ b/pantheon/bootnode_start.sh
@@ -15,4 +15,4 @@
 /opt/pantheon/bin/pantheon $@ --no-discovery export-pub-key /opt/pantheon/public-keys/bootnode
 
 # run bootnode with discovery but no bootnodes as it's our bootnode.
-/opt/pantheon/bin/pantheon $@ --bootnodes=""
+/opt/pantheon/bin/pantheon $@ --bootnodes


### PR DESCRIPTION
--bootnodes option does not accept empty value anymore, it have to be used without value at all.