### PR TITLE
fix docker image and data folder removal

### DIFF
--- a/privacy/pantheon/Dockerfile
+++ b/privacy/pantheon/Dockerfile
@@ -10,8 +10,8 @@ COPY *_start.sh /opt/pantheon/
 COPY orion/* /orion/
 
 # Install a dos 2 unix EOL converter
-RUN apt-get -qq update && \
-    apt-get -qq -y install dos2unix
+RUN apk add --update dos2unix && \
+    rm -rf /var/cache/apk/*
 
 # Run dos2unix EOL conversion on all shell scripts to prevent scripts to fail if edited with a windows IDE
 # that rewrote the EOL to CRLF before we build the image. See issue #4

--- a/privacy/remove.sh
+++ b/privacy/remove.sh
@@ -15,6 +15,18 @@
 
 docker-compose down -v
 docker-compose rm -sfv
-rm -rf pantheon/data*/database/*
-rm -rf pantheon/data*/private*/*
-rm -rf pantheon/data*/uploads/*
+
+rm -rf pantheon/data1/database
+rm -rf pantheon/data1/priv*
+rm -rf pantheon/data1/uploads
+rm -rf pantheon/data1/pantheon.ports
+
+rm -rf pantheon/data2/database
+rm -rf pantheon/data2/priv*
+rm -rf pantheon/data2/uploads
+rm -rf pantheon/data2/pantheon.ports
+
+rm -rf pantheon/data3/database
+rm -rf pantheon/data3/priv*
+rm -rf pantheon/data3/uploads
+rm -rf pantheon/data3/pantheon.ports


### PR DESCRIPTION
quick fix for differences between develop and numbered tagged docker image : 
develop used ubuntu and numbered tag (1.1.0) uses Alpine. Had to switch `apt-get` for `apk`.

and also dirty fix for folders removal as wildcard doesn't work like that in mac
-> To be reworked with volumes