### PR TITLE
Set `--min-gas-price=0` for privacy enabled Pantheon nodes

### DIFF
--- a/privacy/pantheon/node_start.sh
+++ b/privacy/pantheon/node_start.sh
@@ -34,4 +34,4 @@ BOOTNODE_P2P_PORT="30303"
 bootnode_enode_address="enode://${bootnode_pubkey}@${boonode_ip}:${BOOTNODE_P2P_PORT}"
 
 # run with bootnode param
-/opt/pantheon/bin/pantheon $@ --bootnodes=$bootnode_enode_address
+/opt/pantheon/bin/pantheon $@ --bootnodes=$bootnode_enode_address --min-gas-price=0


### PR DESCRIPTION
To keep in sync with https://docs.pantheon.pegasys.tech/en/stable/Privacy/Configuring-Privacy/, update the nodes to start with `--min-gas-price=0`