### PR TITLE
map ports 8545 and 8546 of rpcnode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       - public-keys:${PANTHEON_PUBLIC_KEY_DIRECTORY}
     depends_on:
       - bootnode
+    ports:
+      - "8545:8545"
+      - "8546:8546"
   explorer:
     build: block-explorer-light/.
     image: "quickstart/block-explorer-light:${PANTHEON_VERSION}"


### PR DESCRIPTION
Following [this tutorial](https://medium.com/@josephdelong/fundamentals-of-dapp-development-b97df954a9a), truffle needs 8545 rpc port accessible