### PR TITLE
update to Pantheon 1.1.3 and fix privacy

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 
 # the version of Pantheon Docker image to use.
 # see https://hub.docker.com/r/pegasyseng/pantheon/tags for possible values
-PANTHEON_VERSION=1.1.2
+PANTHEON_VERSION=1.1.3
 QUICKSTART_VERSION=$PANTHEON_VERSION
 # PANTHEON_PUBLIC_KEY_DIRECTORY is the path to use in containers for the mapping of the keys dir volume
 PANTHEON_PUBLIC_KEY_DIRECTORY=/opt/pantheon/public-keys/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /privacy/pantheon/data*/pantheon.ports
 
 ./volumes/
+.DS_Store

--- a/block-explorer-light/Dockerfile-privacy
+++ b/block-explorer-light/Dockerfile-privacy
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY dist /usr/share/nginx/html
+RUN sed -i 's@NODE_ENV:"production",BASE_URL:"/"@NODE_URL:"/rpcnode/jsonrpc",CONNECTION_TYPE:"json_rpc"@g' /usr/share/nginx/html/js/*.js
+COPY privacy.nginx /etc/nginx/conf.d/default.conf

--- a/block-explorer-light/privacy.nginx
+++ b/block-explorer-light/privacy.nginx
@@ -1,0 +1,67 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    # a common HTTP RPC entrypoint mainly for the explorer service
+    location /jsonrpc {
+        rewrite /jsonrpc/?(.*) /$1  break;
+        proxy_pass http://rpcnode:8545;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+
+    # a common WS RPC entrypoint mainly for the explorer service
+    location /jsonws {
+        rewrite /jsonws/?(.*) /$1  break;
+        proxy_pass http://rpcnode:8546;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
+    # a common HTTP GraphQL entrypoint
+    location /graphql {
+      proxy_pass http://rpcnode:8547;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+    }
+
+    # a generic HTTP RPC entrypoint pointing to each available node
+    location ~* /(?<serviceName>(.*))/jsonrpc {
+      # Use Docker default local network DNS IP as resolver
+      resolver 127.0.0.11 ipv6=off;
+      rewrite /jsonrpc/?(.*) /$1  break;
+      proxy_pass http://${serviceName}:8545;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+    }
+
+    # a generic WS RPC entrypoint pointing to each available node
+    location ~* /(?<serviceName>(.*))/jsonws {
+      # Use Docker default local network DNS IP as resolver
+      resolver 127.0.0.11 ipv6=off;
+      rewrite /jsonws/?(.*) /$1  break;
+      proxy_pass http://${serviceName}:8546;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+    }
+
+    location / {
+      root   /usr/share/nginx/html;
+      try_files $uri /index.html;
+      index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+}

--- a/privacy/.env
+++ b/privacy/.env
@@ -3,7 +3,7 @@
 
 # the version of Pantheon Docker image to use.
 # see https://hub.docker.com/r/pegasyseng/pantheon/tags for possible values
-PANTHEON_VERSION=1.1.1
+PANTHEON_VERSION=1.1.3
 ORION_VERSION=0.1.3
 # PANTHEON_PUBLIC_KEY_DIRECTORY is the path to use in containers for the mapping of the volume
 PANTHEON_PUBLIC_KEY_DIRECTORY=/opt/pantheon/public-keys/

--- a/privacy/docker-compose.yml
+++ b/privacy/docker-compose.yml
@@ -137,8 +137,10 @@ services:
     depends_on:
       - bootnode
   explorer:
-    build: ../block-explorer-light
-    image: "quickstart/block-explorer-light:${PANTHEON_VERSION}"
+    build:
+      context: ../block-explorer-light
+      dockerfile: Dockerfile-privacy
+    image: quickstart/block-explorer-light:${PANTHEON_VERSION}-privacy
     depends_on:
       - rpcnode
     ports:


### PR DESCRIPTION
- update to pantheon 1.1.3
- git ignored mac files
- updated privacy explorer service to use a specific dockerfile and nginx conf
 without prometheus (workaround until we merge regular and privacy quickstart)

fixes https://pegasys1.atlassian.net/browse/PAN-2827
See also https://github.com/PegaSysEng/pantheon/pull/1559 for the doc update