### PR TITLE
Update docker files to work with either alpine or ubuntu base images

### DIFF
--- a/pantheon/Dockerfile
+++ b/pantheon/Dockerfile
@@ -6,9 +6,9 @@ FROM pegasyseng/pantheon:$PANTHEON_VERSION
 # Copy new entrypoint scripts
 COPY *_start.sh /opt/pantheon/
 
-# Install a dos 2 unix EOL converter
-RUN apk add --update dos2unix && \
-    rm -rf /var/cache/apk/*
+# Install a dos 2 unix EOL converter (supporting either alpine or ubuntu images)
+RUN (apt-get update && apt-get install dos2unix || apk add --update dos2unix) && \
+    rm -rf /var/cache/apt/* && rm -rf /var/cache/apk/*
 
 # Run dos2unix EOL conversion on all shell scripts to prevent scripts to fail if edited with a windows IDE
 # that rewrote the EOL to CRLF before we build the image. See issue #4

--- a/pantheon_clique/Dockerfile
+++ b/pantheon_clique/Dockerfile
@@ -10,9 +10,9 @@ COPY *_start.sh /opt/pantheon/
 # Copy genesis template
 COPY genesis.json.template /var/lib/pantheon/
 
-# Install a dos 2 unix EOL converter
-RUN apk add --update dos2unix && \
-    rm -rf /var/cache/apk/*
+# Install a dos 2 unix EOL converter (supporting either alpine or ubuntu images)
+RUN (apt-get update && apt-get install dos2unix || apk add --update dos2unix) && \
+    rm -rf /var/cache/apt/* && rm -rf /var/cache/apk/*
 
 # Run dos2unix EOL conversion on all shell scripts to prevent scripts to fail if edited with a windows IDE
 # that rewrote the EOL to CRLF before we build the image. See issue #4

--- a/pantheon_ibft2/Dockerfile
+++ b/pantheon_ibft2/Dockerfile
@@ -10,9 +10,9 @@ COPY *_start.sh /opt/pantheon/
 # Copy genesis template
 COPY genesis.json.template /var/lib/pantheon/
 
-# Install a dos 2 unix EOL converter
-RUN apk add --update dos2unix && \
-    rm -rf /var/cache/apk/*
+# Install a dos 2 unix EOL converter (supporting either alpine or ubuntu images)
+RUN (apt-get update && apt-get install dos2unix || apk add --update dos2unix) && \
+    rm -rf /var/cache/apt/* && rm -rf /var/cache/apk/*
 
 # Run dos2unix EOL conversion on all shell scripts to prevent scripts to fail if edited with a windows IDE
 # that rewrote the EOL to CRLF before we build the image. See issue #4

--- a/privacy/pantheon/Dockerfile
+++ b/privacy/pantheon/Dockerfile
@@ -9,9 +9,9 @@ COPY *_start.sh /opt/pantheon/
 # Copy Orion public keys
 COPY orion/* /orion/
 
-# Install a dos 2 unix EOL converter
-RUN apk add --update dos2unix && \
-    rm -rf /var/cache/apk/*
+# Install a dos 2 unix EOL converter (supporting either alpine or ubuntu images)
+RUN (apt-get update && apt-get install dos2unix || apk add --update dos2unix) && \
+    rm -rf /var/cache/apt/* && rm -rf /var/cache/apk/*
 
 # Run dos2unix EOL conversion on all shell scripts to prevent scripts to fail if edited with a windows IDE
 # that rewrote the EOL to CRLF before we build the image. See issue #4


### PR DESCRIPTION
The new docker image coming with Pantheon 1.2 is based on Ubuntu instead of Alpine so we need to use `apt-get` instead of `apk` to install `dos2unix`.  I've set it up so that it works with either image.

Everything else about the new image works without any modifications needed.