### PR TITLE
Fix block explorer port mapping default value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     depends_on:
       - rpcnode
     ports:
-      - "${EXPLORER_PORT_MAPPING:-}80"
+      - "${EXPLORER_PORT_MAPPING:-0}:80"
 
   prometheus:
     image: "prom/prometheus"


### PR DESCRIPTION
If EXPLORER_PORT_MAPPING value is set, it was getting concatenated with 80. 
E.g., if you set EXPLORER_PORT_MAPPING=99, the port was getting mapped to 9980